### PR TITLE
fix(controller): removes response.send from route handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ import { Response } from "express";
 class MyCustomController extends PrometheusController {
   @Get()
   async index(@Res() response: Response) {
-    await super.index(response);
+    return super.index(response);
   }
 }
 ```

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -11,7 +11,7 @@ import * as client from "prom-client";
 @Controller()
 export class PrometheusController {
   @Get()
-  async index(@Res() response: unknown): Promise<void> {
+  async index(@Res({ passthrough: true }) response: unknown): Promise<string> {
     // See this issue for why we type this as `unknown`
     // https://github.com/willsoto/nestjs-prometheus/issues/530
     // I currently don't know of any type from NestJS that captures the
@@ -19,7 +19,6 @@ export class PrometheusController {
     // download types for a framework they aren't using.
     // @ts-expect-error
     response.header("Content-Type", client.register.contentType);
-    // @ts-expect-error
-    response.send(await client.register.metrics());
+    return client.register.metrics();
   }
 }

--- a/test/custom-controller.spec.ts
+++ b/test/custom-controller.spec.ts
@@ -16,10 +16,9 @@ describe("PrometheusModule with a custom controller", function () {
 
     class CustomController extends PrometheusController {
       @Get()
-      async index(@Res() response: Response) {
-        await super.index(response);
-
+      async index(@Res() response: Response): Promise<string> {
         fake();
+        return super.index(response);
       }
     }
 


### PR DESCRIPTION
Calling `response.send` in the controller prevents interceptos from being able to modify the response object further down the line like, for example, setting headers

It's important to notice that a custom controller that extends the PrometheusController in the same manner as the one in the spec will stop working after this modification

This should be easy to test with a simple interceptor

```javascript
@Injectable()
export class CustomInterceptor implements NestInterceptor {
  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
    const res = context.switchToHttp().getResponse<Response>();
    return next.handle().pipe(
      tap(() => {
        res.setHeader('x-test', 'test');
      }),
    );
  }
}
```