### PR TITLE
fix: decorator types

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -24,7 +24,7 @@ export function InjectMetric(
   name: string,
 ): (
   target: Record<string, unknown>,
-  key: string | symbol,
+  key: string | symbol | undefined,
   index?: number | undefined,
 ) => void {
   const token = getToken(name);

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -23,7 +23,7 @@ import { getToken } from "./metrics";
 export function InjectMetric(
   name: string,
 ): (
-  target: Record<string, unknown>,
+  target: object,
   key: string | symbol | undefined,
   index?: number | undefined,
 ) => void {


### PR DESCRIPTION
Hello. I have had a problem for a while where Visual Studio Code would give me errors about the InjectMetrics decorator but I would still be able to build and run my code. I have now tried to update my project to TypeScript v5 and I can't build my project anymore. The error it gives in the build logs is the same error that Visual Studio Code has given me for a while, so I assume it is because some extension I use moved to TypeScript v5.

I found this issue https://github.com/willsoto/nestjs-prometheus/issues/1667 that had the same errors as me, but the comments didn't help. I also found a different issue https://github.com/nestjs/nest/issues/10959, and the fix they used https://github.com/nestjs/nest/pull/10970, and used that to fix the problem with the InjectMetric decorator.

The problem is that the decorator types are wrong. Record<string, unknown> fails with strict checks, and the key may also be undefined.

Fixes #1667