### PR TITLE
fix: inject error of pushgateway #1780

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -27,10 +27,12 @@ export class PrometheusModule {
     PrometheusModule.configureServer(opts);
 
     const providers: Provider[] = [];
+    const moduleExtend: { exports: Provider[] } = {
+      exports: [],
+    };
     if (options?.pushgateway !== undefined) {
       const { url, options: gatewayOptions, registry } = options.pushgateway;
-
-      providers.push({
+      moduleExtend["exports"].push({
         provide: promClient.Pushgateway,
         useValue: PrometheusModule.configurePushgateway(
           url,
@@ -38,12 +40,14 @@ export class PrometheusModule {
           registry,
         ),
       });
+      providers.push(...moduleExtend["exports"]);
     }
 
     return {
       module: PrometheusModule,
       providers,
       controllers: [opts.controller],
+      ...moduleExtend,
     };
   }
 
@@ -56,6 +60,7 @@ export class PrometheusModule {
       controllers: [controller],
       imports: options.imports,
       providers: [...asyncProviders],
+      exports: [asyncProviders[asyncProviders.length - 1]],
     };
   }
 

--- a/test/push-gateway.spec.ts
+++ b/test/push-gateway.spec.ts
@@ -1,7 +1,12 @@
 import { Injectable, Module } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
 import { expect } from "chai";
 import { Pushgateway, register } from "prom-client";
-import { PrometheusOptions, PrometheusOptionsFactory } from "../src";
+import {
+  PrometheusModule,
+  PrometheusOptions,
+  PrometheusOptionsFactory,
+} from "../src";
 import { createAsyncPrometheusModule, createPrometheusModule } from "./utils";
 
 describe("Pushgateway", function () {
@@ -14,6 +19,11 @@ describe("Pushgateway", function () {
         },
       };
     }
+  }
+
+  @Injectable()
+  class MockService {
+    constructor(public readonly pushgateway: Pushgateway) {}
   }
 
   @Module({
@@ -50,5 +60,41 @@ describe("Pushgateway", function () {
     expect(gateway).to.be.instanceOf(Pushgateway);
 
     await app.close();
+  });
+
+  it("should be injected in another provider for sync", async function () {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        PrometheusModule.register({
+          pushgateway: {
+            url: "http://127.0.0.1:9091",
+          },
+        }),
+      ],
+      providers: [MockService],
+    }).compile();
+    const mockService = moduleRef.get<MockService>(MockService);
+    expect(mockService.pushgateway).to.be.an.instanceOf(Pushgateway);
+    expect(mockService.pushgateway).to.have.property(
+      "gatewayUrl",
+      "http://127.0.0.1:9091",
+    );
+  });
+
+  it("should be injected in another provider for async", async function () {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        PrometheusModule.registerAsync({
+          useClass: OptionsService,
+        }),
+      ],
+      providers: [MockService],
+    }).compile();
+    const mockService = moduleRef.get<MockService>(MockService);
+    expect(mockService.pushgateway).to.be.an.instanceOf(Pushgateway);
+    expect(mockService.pushgateway).to.have.property(
+      "gatewayUrl",
+      "http://127.0.0.1:9091",
+    );
   });
 });


### PR DESCRIPTION
Hi, 
Pushgateway is not working, because the unit test did cover the situation about the inject process in another provider

---
fix the unit test and export the pushgateway in the PrometheusModule

- refer to https://github.com/willsoto/nestjs-prometheus/issues/1780