### PR TITLE
Feat: allow the module to be registered as global

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,6 +27,10 @@ export interface PrometheusDefaultMetrics {
  */
 export interface PrometheusOptions {
   /**
+   * Make the module global when set to true
+   * */
+  global?: boolean;
+  /**
    * Similar to `defaultMetrics.prefix`, this will be applied to each custom
    * metric created using the various providers. Will suffix the given prefix
    * with `_`.
@@ -98,6 +102,8 @@ export interface PrometheusOptionsFactory {
  */
 export interface PrometheusAsyncOptions
   extends Pick<ModuleMetadata, "imports"> {
+  global?: boolean;
+
   useExisting?: Type<PrometheusOptionsFactory>;
   useClass?: Type<PrometheusOptionsFactory>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/module.ts
+++ b/src/module.ts
@@ -46,6 +46,7 @@ export class PrometheusModule {
 
     return {
       module: PrometheusModule,
+      global: opts.global,
       providers,
       controllers: [opts.controller],
       exports: providers,
@@ -58,6 +59,7 @@ export class PrometheusModule {
 
     return {
       module: PrometheusModule,
+      global: options.global,
       controllers: [controller],
       imports: options.imports,
       providers: [
@@ -181,6 +183,7 @@ export class PrometheusModule {
     options?: PrometheusOptions,
   ): PrometheusOptionsWithDefaults {
     return {
+      global: false,
       path: "/metrics",
       defaultMetrics: {
         enabled: true,


### PR DESCRIPTION
Adds another module parameter that makes the module globally available. Allows anyone to create a PrometheusModule in the root and then create metrics where they want, which is cleaner and less work then solutions like:
```ts
@Module({
  imports: [PrometheusModule.register()],
  exports: [PrometheusModule]
})
@Global()
class SomeModule {}
// or worse
{...PrometheusModule.register(), global: true}
```
This should not introduce any breaking changes.