### PR TITLE
fix: allow nestjs 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "typescript": "5.7.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "prom-client": "^15.0.0"
   },
   "packageManager": "pnpm@9.15.3",


### PR DESCRIPTION
Fixes

```
  Type 'import("/home/runner/work/btp/btp/node_modules/@willsoto/nestjs-prometheus/node_modules/@nestjs/common/interfaces/modules/dynamic-module.interface").DynamicModule' is not assignable to type 'import("/home/runner/work/btp/btp/node_modules/@nestjs/common/interfaces/modules/dynamic-module.interface").DynamicModule'.
    Types of property 'imports' are incompatible.
      Type '(DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>)[] | undefined' is not assignable to type '(Type<any> | ForwardReference<any> | DynamicModule | Promise<DynamicModule>)[] | undefined'.
        Type '(DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>)[]' is not assignable to type '(Type<any> | ForwardReference<any> | DynamicModule | Promise<DynamicModule>)[]'.
          Type 'DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>' is not assignable to type 'Type<any> | ForwardReference<any> | DynamicModule | Promise<DynamicModule>'.
            Type 'Promise<DynamicModule>' is not assignable to type 'Type<any> | ForwardReference<any> | DynamicModule | Promise<DynamicModule>'.
```